### PR TITLE
remove `any` usage + improve filtering

### DIFF
--- a/src/interface/report/Results/Timeline/EnemyCasts.tsx
+++ b/src/interface/report/Results/Timeline/EnemyCasts.tsx
@@ -378,7 +378,7 @@ export const EnemyCastsTimeline = ({
                 dmgEvent.timestamp >= event.timestamp &&
                 dmgEvent.timestamp <= event.timestamp + 10000 && //Assumes a damage event from an npc ability happens within 10 seconds
                 dmgEvent.sourceID === event.sourceID &&
-                dmgEvent.ability.name === event.ability.name
+                dmgEvent.ability.name === event.ability.name // we are intentionally using the name here instead of guid to account for casts having different spell ids from damage
               );
             });
             return (


### PR DESCRIPTION
this removes the use of `any` in the implementation of the enemy cast timeline, as well as further refinement of the filters used.

- added an `EXCLUDED_SPELLS` list that can be used to remove fake/cosmetic spells. this will come up in raids more than in M+ but some of these are very spammy
- add additional filters to the damage lookup to exclude immune/deflect events. some non-damage events log as "damage" because of how they interact with immunes like bubble and deflects like Turtle.
- always include boss casts, even if they don't have damage. on bosses, the damage spell is often different from the actual spell cast. this causes all boss mechanics to be included.
- use `sourceInstance` to clean up damage event matching. this came up on Tindral where you have ~18 treants up at one point and the timeline got very confused from all those casts with the same source ID. they have different instance IDs, so this fixed it.
